### PR TITLE
Add private endpoint connection ops to get, approve, reject, delete for 2020-09-30

### DIFF
--- a/specification/compute/resource-manager/Microsoft.Compute/stable/2020-09-30/disk.json
+++ b/specification/compute/resource-manager/Microsoft.Compute/stable/2020-09-30/disk.json
@@ -1344,6 +1344,157 @@
         }
       }
     },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/diskAccesses/{diskAccessName}/privateEndpointConnections/{privateEndpointConnectionName}": {
+      "put": {
+        "tags": [
+          "DiskAccesses"
+        ],
+        "operationId": "PrivateEndpointConnections_Approve_Reject",
+        "description": "Approve or reject a private endpoint connection under disk access resource, this can't be used to create a new private endpoint connection.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/DiskAccessNameParameter"
+          },
+          {
+            "$ref": "#/parameters/PrivateEndpointConnectionNameParameter"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "privateEndpointConnection",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/PrivateEndpointConnection"
+            },
+            "description": "private endpoint connection object supplied in the body of the Put private endpoint connection operation."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/PrivateEndpointConnection"
+            }
+          },
+          "202": {
+            "description": "Accepted",
+            "schema": {
+              "$ref": "#/definitions/PrivateEndpointConnection"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Approve a Private Endpoint Connection under a disk access resource.": {
+            "$ref": "./examples/ApprovePrivateEndpointConnection.json"
+          }
+        },
+        "x-ms-long-running-operation": true
+      },
+      "get": {
+        "tags": [
+          "DiskAccesses"
+        ],
+        "operationId": "PrivateEndpointConnections_Get",
+        "description": "Gets information about a private endpoint connection under a disk access resource.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/DiskAccessNameParameter"
+          },
+          {
+            "$ref": "#/parameters/PrivateEndpointConnectionNameParameter"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/PrivateEndpointConnection"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get information about a private endpoint connection under a disk access resource.": {
+            "$ref": "./examples/GetInformationAboutAPrivateEndpointConnection.json"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "DiskAccesses"
+        ],
+        "operationId": "PrivateEndpointConnections_Delete",
+        "description": "Deletes a private endpoint connection under a disk access resource.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/DiskAccessNameParameter"
+          },
+          {
+            "$ref": "#/parameters/PrivateEndpointConnectionNameParameter"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "202": {
+            "description": "Accepted"
+          },
+          "204": {
+            "description": "If the private endpoint connection is already deleted, this is an expected error code."
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Delete a private endpoint connection under a disk access resource.": {
+            "$ref": "./examples/DeleteAPrivateEndpointConnection.json"
+          }
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
     "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/restorePointCollections/{restorePointCollectionName}/restorePoints/{vmRestorePointName}/diskRestorePoints/{diskRestorePointName}": {
       "get": {
         "tags": [

--- a/specification/compute/resource-manager/Microsoft.Compute/stable/2020-09-30/disk.json
+++ b/specification/compute/resource-manager/Microsoft.Compute/stable/2020-09-30/disk.json
@@ -1349,7 +1349,7 @@
         "tags": [
           "DiskAccesses"
         ],
-        "operationId": "PrivateEndpointConnections_Approve_Reject",
+        "operationId": "DiskAccesses_UpdateAPrivateEndpointConnection",
         "description": "Approve or reject a private endpoint connection under disk access resource, this can't be used to create a new private endpoint connection.",
         "parameters": [
           {
@@ -1408,7 +1408,7 @@
         "tags": [
           "DiskAccesses"
         ],
-        "operationId": "PrivateEndpointConnections_Get",
+        "operationId": "DiskAccesses_GetAPrivateEndpointConnection",
         "description": "Gets information about a private endpoint connection under a disk access resource.",
         "parameters": [
           {
@@ -1451,7 +1451,7 @@
         "tags": [
           "DiskAccesses"
         ],
-        "operationId": "PrivateEndpointConnections_Delete",
+        "operationId": "DiskAccesses_DeleteAPrivateEndpointConnection",
         "description": "Deletes a private endpoint connection under a disk access resource.",
         "parameters": [
           {

--- a/specification/compute/resource-manager/Microsoft.Compute/stable/2020-09-30/examples/ApprovePrivateEndpointConnection.json
+++ b/specification/compute/resource-manager/Microsoft.Compute/stable/2020-09-30/examples/ApprovePrivateEndpointConnection.json
@@ -1,0 +1,47 @@
+{
+  "parameters": {
+    "subscriptionId": "{subscription-id}",
+    "resourceGroupName": "myResourceGroup",
+    "api-version": "2020-09-30",
+    "diskAccessName": "myDiskAccess",
+    "privateEndpointConnectionName": "myPrivateEndpointConnection",
+    "privateEndpointConnection": {
+      "properties": {
+        "privateLinkConnectionState": {
+          "status": "Approved",
+          "description": "Approving myPrivateEndpointConnection"
+        }
+      },
+      "name": "myPrivateEndpointConnection"
+    }
+  },
+  "responses": {
+    "202": {
+      "body": {
+        "name": "myPrivateEndpointConenction",
+        "type": "Microsoft.Compute/diskAccesses/privateEndpointConnections",
+        "properties": {
+          "provisioningState": "Updating"
+        }
+      }
+    },
+    "200": {
+      "body": {
+        "name": "myPrivateEndpointConnectionName",
+        "type": "Microsoft.Compute/diskAccesses/PrivateEndpointConnections",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/myResourceGroup/providers/Microsoft.Compute/diskAccesses/myDiskAccess/privateEndpoinConnections/myPrivateEndpointConnectionName",
+        "properties": {
+          "provisioningState": "Succeeded",
+          "privateEndpoint": {
+            "id": "/subscriptions/{subscription-id}/resourceGroups/myResourceGroup/providers/Microsoft.Network/privateEndpoints/myPrivateEndpoint"
+          },
+          "privateLinkServiceConnectionState": {
+            "actionsRequired": "None",
+            "description": "Approving myPrivateEndpointConnection",
+            "status": "Approved"
+          }
+        }
+      }
+    }
+  }
+}

--- a/specification/compute/resource-manager/Microsoft.Compute/stable/2020-09-30/examples/DeleteAPrivateEndpointConnection.json
+++ b/specification/compute/resource-manager/Microsoft.Compute/stable/2020-09-30/examples/DeleteAPrivateEndpointConnection.json
@@ -1,0 +1,14 @@
+{
+  "parameters": {
+    "subscriptionId": "{subscription-id}",
+    "resourceGroupName": "myResourceGroup",
+    "diskAccessName": "myDiskAccess",
+    "privateEndpointConnectionName": "myPrivateEndpointConnection",
+    "api-version": "2020-09-30"
+  },
+  "responses": {
+    "200": {},
+    "202": {},
+    "204": {}
+  }
+}

--- a/specification/compute/resource-manager/Microsoft.Compute/stable/2020-09-30/examples/GetInformationAboutAPrivateEndpointConnection.json
+++ b/specification/compute/resource-manager/Microsoft.Compute/stable/2020-09-30/examples/GetInformationAboutAPrivateEndpointConnection.json
@@ -1,0 +1,29 @@
+{
+  "parameters": {
+    "subscriptionId": "{subscription-id}",
+    "resourceGroupName": "myResourceGroup",
+    "api-version": "2020-09-30",
+    "diskAccessName": "myDiskAccess",
+    "privateEndpointConnectionName": "myPrivateEndpointConnection"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "myPrivateEndpointConnection",
+        "type": "Microsoft.Compute/diskAccesses/PrivateEndpointConnections",
+        "id": "/subscriptions/{subscription-id}/resourceGroups/myResourceGroup/providers/Microsoft.Compute/diskAccesses/myDiskAccess/privateEndpoinConnections/myPrivateEndpointConnection",
+        "properties": {
+          "provisioningState": "Succeeded",
+          "privateEndpoint": {
+            "id": "/subscriptions/{subscription-id}/resourceGroups/myResourceGroup/providers/Microsoft.Network/privateEndpoints/myPrivateEndpoint"
+          },
+          "privateLinkServiceConnectionState": {
+            "actionsRequired": "None",
+            "description": "Auto-Approved",
+            "status": "Approved"
+          }
+        }
+      }
+    }
+  }
+}

--- a/specification/compute/resource-manager/readme.md
+++ b/specification/compute/resource-manager/readme.md
@@ -253,6 +253,7 @@ These settings apply only when `--tag=package-2020-09-30-only` is specified on t
 
 ``` yaml $(tag) == 'package-2020-09-30-only'
 input-file:
+- Microsoft.Compute/stable/2020-09-30/disk.json
 - Microsoft.Compute/preview/2020-09-30/gallery.json
 - Microsoft.Compute/preview/2020-09-30/sharedGallery.json
 ```


### PR DESCRIPTION
<i>MSFT employees can try out our new experience at <b>[OpenAPI Hub](https://aka.ms/openapiportal) </b> - one location for using our validation tools and finding your workflow. 
</i>

### Contribution checklist:
- [x] I commit to follow the [Breaking Change Policy](http://aka.ms/bcforapi) of “no breaking changes
- [x] I have reviewed the [documentation](https://aka.ms/ameonboard) for the workflow.
- [x] [Validation tools](https://aka.ms/swaggertools) were run on swagger spec(s) and errors have all been fixed in this PR. [How to fix?](https://aka.ms/ci-fix)

If any further question about AME onboarding or validation tools, please view the [FAQ](https://aka.ms/faqinprreview).

### ARM API Review Checklist
- [ ] Ensure to check this box if one of the following scenarios meet updates in the PR, so that label “WaitForARMFeedback” will be added automatically to involve ARM API Review. Failure to comply may result in delays for manifest application. Note this does not apply to data plane APIs, all “removals” and “adding a new property” no more require ARM API review.
  - Adding new API(s)
  - Adding a new API version
  - Adding a new service

- [ ] If you are blocked on ARM review and want to get the PR merged with urgency, please get the ARM oncall for reviews (*RP Manifest Approvers* team under <ins>Azure Resource Manager service</ins>) from IcM and reach out to them. 

### Breaking Change Review Checklist 
If there are following updates in the PR, ensure to request an approval from API Review Board as defined in the [Breaking Change Policy](http://aka.ms/bcforapi). 

- [ ] Removing API(s) in stable version
- [ ] Removing properties in stable version
- [ ] Removing API version(s) in stable version
- [ ] Updating API in stable version with Breaking Change Validation errors
- [ ] Updating API(s) in preview over 1 year

Please follow the link to find more details on [PR review process](https://aka.ms/SwaggerPRReview).